### PR TITLE
fix(loop): credit full CPS when a backgrounded tab resumes

### DIFF
--- a/src/Game.Core/Domain/GameState.cs
+++ b/src/Game.Core/Domain/GameState.cs
@@ -204,6 +204,58 @@ public sealed class GameState
     }
 
     /// <summary>
+    /// Catch up on real time that elapsed while the tab was merely backgrounded
+    /// (not closed): the browser throttles background timers hard, so the game
+    /// loop stops ticking at 30fps and, when it fires again, hands us one large
+    /// gap. This credits that gap at <b>full</b> efficiency — the session never
+    /// actually ended, so unlike <see cref="ApplyOfflineProgress"/> there is no
+    /// 50% haircut and no minimum-report threshold.
+    ///
+    /// Why this is not just a big <see cref="Tick"/>:
+    /// <list type="bullet">
+    /// <item>Cookies are credited at <see cref="CurrentCpsRaw"/>, not
+    /// <see cref="CurrentCps"/>, so a temporary Frenzy that is about to expire
+    /// is not stretched across the whole away-window (same reasoning as offline
+    /// progress).</item>
+    /// <item>Golden cookies are not spawned/expired in a burst: the schedule is
+    /// simply pushed forward, mirroring <see cref="ApplyOfflineProgress"/>.</item>
+    /// </list>
+    /// </summary>
+    public void CatchUpProgress(double realSeconds)
+    {
+        if (realSeconds <= 0) return;
+
+        // Credit cookies at the pre-buff rate captured *before* advancing the
+        // clock (so buffs still active for this window are counted, but not
+        // stretched past their expiry).
+        var cps = CurrentCpsRaw();
+        if (cps > 0)
+        {
+            var gained = cps * realSeconds;
+            Cookies += gained;
+            AddBaked(gained);
+        }
+
+        // Advance the world clock and expire anything that timed out while away.
+        GameTime += realSeconds;
+        Buffs.RemoveAll(b => b.ExpiresAt <= GameTime);
+
+        // Ripen the pending sugar lump if its window passed.
+        if (!SugarLumpReady && AllTimeCookiesBaked >= ProgressionConfig.SugarLumpUnlockThreshold
+            && GameTime >= SugarLumpNextAt)
+        {
+            SugarLumpReady = true;
+            _newsMessages.Enqueue(NewsMessage.Of("news.event.sugar_ripe"));
+        }
+
+        // Don't dump a burst of golden cookies for the missed time; just resume
+        // the cadence shortly after we're back in the foreground.
+        if (_nextGoldenAt < GameTime) _nextGoldenAt = GameTime + 15 + _random.NextDouble() * 60;
+
+        CheckAchievements();
+    }
+
+    /// <summary>
     /// Simulate a period the player spent away from the tab. Grants a
     /// reduced-efficiency cookie yield and advances timers.
     /// </summary>

--- a/src/Game.Web/Services/GameLoop.cs
+++ b/src/Game.Web/Services/GameLoop.cs
@@ -16,6 +16,15 @@ public sealed class GameLoop : IDisposable
     private readonly SaveCoordinator _save;
     private DateTime _lastTick = DateTime.UtcNow;
 
+    /// <summary>
+    /// Frame gaps larger than this (seconds) are treated as "the tab was
+    /// backgrounded / the machine slept" and credited via
+    /// <see cref="GameState.CatchUpProgress"/> rather than a normal tick. A few
+    /// seconds is comfortably above a foreground frame (~0.03s) yet below any
+    /// real absence, so a brief GC/scheduler hiccup still ticks normally.
+    /// </summary>
+    private const double CatchUpThresholdSeconds = 3.0;
+
     public event Action? OnTick;
 
     public GameLoop(SaveCoordinator save)
@@ -39,9 +48,22 @@ public sealed class GameLoop : IDisposable
         var now = DateTime.UtcNow;
         var delta = (now - _lastTick).TotalSeconds;
         _lastTick = now;
-        if (delta > 5) delta = 5;
 
-        _save.State.Tick(delta);
+        // A normal foreground frame is ~1/30s. A much larger gap means the tab
+        // was backgrounded (browsers throttle background timers to ~1/s or less)
+        // or the machine slept: the timer stopped firing and this single wake-up
+        // carries all the missed wall-clock time. Feeding that straight into
+        // Tick would stretch an expiring Frenzy across the whole window and spawn
+        // a burst of golden cookies, so route it through the dedicated catch-up
+        // path instead, which credits full CPS without those artifacts.
+        if (delta > CatchUpThresholdSeconds)
+        {
+            _save.State.CatchUpProgress(delta);
+        }
+        else if (delta > 0)
+        {
+            _save.State.Tick(delta);
+        }
 
         // Autosave throttling lives inside SaveCoordinator.
         try { await _save.MaybeAutosaveAsync(); } catch { /* ignore transient JS interop errors */ }

--- a/tests/Game.Core.Tests/ProgressionTests.cs
+++ b/tests/Game.Core.Tests/ProgressionTests.cs
@@ -250,6 +250,71 @@ public class ProgressionTests
     }
 
     // ------------------------------------------------------------------
+    // Catch-up progress (tab backgrounded, not closed — full efficiency)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CatchUp_CreditsCookiesAtFullEfficiency()
+    {
+        var s = new GameState { Cookies = 10_000 };
+        s.BuyBuildingBulk(BuildingId.Grandma, 10); // 10 CPS
+        var cps = s.CurrentCpsRaw();
+        Assert.Equal(10, cps, 6);
+
+        var before = s.Cookies;
+        s.CatchUpProgress(60); // 1 minute backgrounded
+        // No 50% haircut, unlike ApplyOfflineProgress.
+        var expected = cps * 60;
+        Assert.Equal(before + expected, s.Cookies, 4);
+    }
+
+    [Fact]
+    public void CatchUp_AdvancesGameClock()
+    {
+        var s = new GameState { Cookies = 10_000 };
+        s.BuyBuildingBulk(BuildingId.Grandma, 5);
+        var before = s.GameTime;
+
+        s.CatchUpProgress(120);
+
+        Assert.Equal(before + 120, s.GameTime, 6);
+    }
+
+    [Fact]
+    public void CatchUp_DoesNotStretchExpiringFrenzyAcrossWindow()
+    {
+        var s = new GameState { Cookies = 10_000 };
+        s.BuyBuildingBulk(BuildingId.Grandma, 10); // 10 raw CPS
+        var raw = s.CurrentCpsRaw();
+
+        // A x7 Frenzy that expires almost immediately must not inflate a long
+        // catch-up window: catch-up credits raw CPS, and the buff is expired
+        // once the clock advances past it.
+        s.Buffs.Add(new ActiveBuff(GoldenCookieEffect.Frenzy, 7.0, s.GameTime + 1));
+
+        var before = s.Cookies;
+        s.CatchUpProgress(600); // 10 minutes
+
+        Assert.Equal(before + raw * 600, s.Cookies, 4);
+        Assert.Empty(s.Buffs); // the frenzy expired, not carried forward
+    }
+
+    [Fact]
+    public void CatchUp_NonPositiveIsNoOp()
+    {
+        var s = new GameState { Cookies = 500 };
+        s.BuyBuildingBulk(BuildingId.Grandma, 3);
+        var cookies = s.Cookies;
+        var time = s.GameTime;
+
+        s.CatchUpProgress(0);
+        s.CatchUpProgress(-10);
+
+        Assert.Equal(cookies, s.Cookies);
+        Assert.Equal(time, s.GameTime);
+    }
+
+    // ------------------------------------------------------------------
     // News queue
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Passive cookie production is credited too low whenever the tab spends time **in the background**.

`GameLoop` is driven by a `System.Timers.Timer` that ticks ~30fps and advances the sim by the real wall-clock delta since the last tick. Browsers **throttle background-tab timers** hard (to ~1/s, often ~1/min, or pause them entirely on sleep/mobile). When the timer does fire again it hands over one large elapsed gap — but the old code clamped it:

```csharp
var delta = (now - _lastTick).TotalSeconds;
_lastTick = now;
if (delta > 5) delta = 5;   // ← discards everything past 5s
_save.State.Tick(delta);
```

So a backgrounded tab is credited only ~5s of CPS per throttled tick instead of the true time away. The 5s clamp existed for a good reason (ADR 0002 §7: avoid an "8h away → instant cookie explosion" and a golden-cookie burst in one giant `Tick`), but it throws the time away rather than accounting for it. The proper long-gap path (`ApplyOfflineProgress`) only ran on **page load**, never when a tab was merely backgrounded and refocused.

## Live verification

Two tabs, same machine, backgrounded together for ~8 minutes, read from the persisted save (`Δcookies / Δ(savedAtUnix)` = measured CPS):

| Build | Δcookies | Δseconds | Measured CPS |
|---|---:|---:|---:|
| **Before** (deployed `main`, gh-pages) | 6,374,022,650 | 506 | **≈ 12.60 M** |
| **After** (this fix, local) | 8,716,049,809 | 490 | **≈ 17.79 M** |

The two tabs were at different progression, so the meaningful comparison is *measured CPS vs. each tab's own nominal CPS*: the unfixed build measured **well below** its nominal rate (time lost to the clamp), while the fixed build measured **≈ its nominal rate** — background time now credited in full. Bug reproduced and fix confirmed.

## Fix

- **`GameState.CatchUpProgress(realSeconds)`** (new) — credits the missed time at **full efficiency** using `CurrentCpsRaw()` (so a Frenzy about to expire isn't stretched across the whole window), advances the clock, ripens the pending sugar lump, and **pushes the golden-cookie schedule forward** instead of spawning a burst. Same artifact-avoidance as `ApplyOfflineProgress`, but without offline's 50% haircut — the session never actually ended.
- **`GameLoop`** — gaps over a **3s** threshold route through `CatchUpProgress`; smaller gaps tick normally (so golden cookies still spawn as usual in the foreground).

### Note: behavioral choice

A *backgrounded* tab now earns **100%**, while a *fully closed* tab (reload → `ApplyOfflineProgress`) still earns **50%**. This is a deliberate choice — a backgrounded session hasn't ended. Happy to unify the two if the maintainer prefers a single efficiency rate.

## Tests

Four new tests in `ProgressionTests.cs` (full-efficiency credit, clock advance, no-Frenzy-stretch, no-op guard). Full suite green: **142 Core + 26 Web**, `dotnet build -c Release` clean (0 warnings, 0 errors).

---
*Opened from a fork because I don't have push access to this repo. Filed at the author's request.*
